### PR TITLE
Create sieubeobeo

### DIFF
--- a/sieubeobeo
+++ b/sieubeobeo
@@ -1,0 +1,13 @@
+<p>Cho đến ngày nay, câu hỏi về người thực sự tạo ra chú gấu bông đầu tiên vẫn còn được tranh luận. Bất kể ai là người đầu tiên, gấu Theodore trở thành nỗi ám ảnh quốc gia. Năm 1903, Steiff đã sản xuất 12.000 con gấu. Các nhà sản xuất Teddy nở rộ. Nhà văn sách giáo khoa Seymour Eaton, với bút danh Paul Piper, đã viết một bài thơ hấp dẫn có tên &quot;The Roosevelt Bears&quot; xuất hiện mỗi tuần trên các tờ báo trên khắp đất nước và theo dõi những trò hề của &quot;Teddy-B và Teddy-G&quot;.</p>
+
+<p>Eaton cũng xuất bản một loạt sách về những con gấu. &quot;Gấu bông là tất cả cơn thịnh nộ&quot;, đọc một quảng cáo trong danh mục 1908 Sears, Roebuck. Gấu đủ loại - gấu kẻ sọc, gấu mờ, gấu Viking - cá rô trên mọi bề mặt có sẵn. Làm thế nào về một con gấu có mũ trùm đầu với dụng cụ uốn tóc và dép mờ và áo choàng? Nó cũng ở đó.</p>
+
+<p>Và hôm nay Vermont TeddyBears - Hầu hết khách hàng của Vermont Teddy là những người đàn ông gửi Bear-Grams. Bear-Grams tùy chỉnh có thể có giá lên tới 300 đô la. Mặc dù công ty chuyên về sự nhẹ dạ - họ vận chuyển từng con gấu trong một thùng chứa đầy lỗ thông hơi và một món kẹo ngon, trong trường hợp con gấu bị đói trong chuyến đi - đó là một công việc đầy đủ.</p>
+
+<p>Những con gấu thực sự phải đối mặt với những kẻ săn bắn và mất môi trường sống, nhưng không có dấu hiệu gấu bông nào sẽ bị đe dọa. Nếu bạn xem qua các tạp chí nổi tiếng, luôn có một quảng cáo cho một số phiên bản giới hạn, và bạn vào một cửa hàng quà tặng và có tạp dề gấu và cốc gấu bông và gấu bông này và gấu bông đó.</p>
+
+<p>Bảo tàng gấu Teddy ở Naples, Florida - một trong những bảo tàng đầu tiên ở Mỹ - trưng bày khoảng năm nghìn teddies từ khắp nơi trên thế giới. Một số người đang giữ gấu bông của riêng họ; những người khác mặc đồ trang sức gấu và mang túi xách gấu. Trải nghiệm mê hoặc cho trẻ em ở mọi lứa tuổi, bảo tàng đặc biệt này trưng bày những chú gấu với đủ hình dạng và kích cỡ bao gồm gấu bông có một không hai, phiên bản giới hạn, gấu cổ và màn hình di chuyển độc đáo.</p>
+
+<p>Năm 1997, khu nghỉ dưỡng Huis Ten Bosch ở Nagasaki, Nhật Bản, đã tiết lộ Vương quốc gấu Teddy - một bản tái tạo rộng 1.300 mét vuông của một thành trì thời trung cổ với mười lăm trăm con gấu cổ điển và mới. Vào ngày 24 tháng 4 năm 2001, Jesse Kim, chủ tịch của JS International, người đã trả thù lao 193,477 đô la cho một con gấu Steiff có một không hai tại một cuộc đấu giá từ thiện, đã mở Bảo tàng gấu JeJu ở Hàn Quốc. Bảo tàng gấu Teddy Jeju mở cửa đặc biệt dành cho các nhà sưu tập châu Âu và vô cùng phấn khích hơn bao giờ hết với trò giải trí &quot;gấu Teddy&quot; đặc biệt.</p>
+
+<p><strong><a href="http://spineditor.com">Đã test được anh ơi </a></strong></p>


### PR DESCRIPTION
<p>Cho đến ngày nay, câu hỏi về người thực sự tạo ra chú gấu bông đầu tiên vẫn còn được tranh luận. Bất kể ai là người đầu tiên, gấu Theodore trở thành nỗi ám ảnh quốc gia. Năm 1903, Steiff đã sản xuất 12.000 con gấu. Các nhà sản xuất Teddy nở rộ. Nhà văn sách giáo khoa Seymour Eaton, với bút danh Paul Piper, đã viết một bài thơ hấp dẫn có tên &quot;The Roosevelt Bears&quot; xuất hiện mỗi tuần trên các tờ báo trên khắp đất nước và theo dõi những trò hề của &quot;Teddy-B và Teddy-G&quot;.</p>

<p>Eaton cũng xuất bản một loạt sách về những con gấu. &quot;Gấu bông là tất cả cơn thịnh nộ&quot;, đọc một quảng cáo trong danh mục 1908 Sears, Roebuck. Gấu đủ loại - gấu kẻ sọc, gấu mờ, gấu Viking - cá rô trên mọi bề mặt có sẵn. Làm thế nào về một con gấu có mũ trùm đầu với dụng cụ uốn tóc và dép mờ và áo choàng? Nó cũng ở đó.</p>

<p>Và hôm nay Vermont TeddyBears - Hầu hết khách hàng của Vermont Teddy là những người đàn ông gửi Bear-Grams. Bear-Grams tùy chỉnh có thể có giá lên tới 300 đô la. Mặc dù công ty chuyên về sự nhẹ dạ - họ vận chuyển từng con gấu trong một thùng chứa đầy lỗ thông hơi và một món kẹo ngon, trong trường hợp con gấu bị đói trong chuyến đi - đó là một công việc đầy đủ.</p>

<p>Những con gấu thực sự phải đối mặt với những kẻ săn bắn và mất môi trường sống, nhưng không có dấu hiệu gấu bông nào sẽ bị đe dọa. Nếu bạn xem qua các tạp chí nổi tiếng, luôn có một quảng cáo cho một số phiên bản giới hạn, và bạn vào một cửa hàng quà tặng và có tạp dề gấu và cốc gấu bông và gấu bông này và gấu bông đó.</p>

<p>Bảo tàng gấu Teddy ở Naples, Florida - một trong những bảo tàng đầu tiên ở Mỹ - trưng bày khoảng năm nghìn teddies từ khắp nơi trên thế giới. Một số người đang giữ gấu bông của riêng họ; những người khác mặc đồ trang sức gấu và mang túi xách gấu. Trải nghiệm mê hoặc cho trẻ em ở mọi lứa tuổi, bảo tàng đặc biệt này trưng bày những chú gấu với đủ hình dạng và kích cỡ bao gồm gấu bông có một không hai, phiên bản giới hạn, gấu cổ và màn hình di chuyển độc đáo.</p>

<p>Năm 1997, khu nghỉ dưỡng Huis Ten Bosch ở Nagasaki, Nhật Bản, đã tiết lộ Vương quốc gấu Teddy - một bản tái tạo rộng 1.300 mét vuông của một thành trì thời trung cổ với mười lăm trăm con gấu cổ điển và mới. Vào ngày 24 tháng 4 năm 2001, Jesse Kim, chủ tịch của JS International, người đã trả thù lao 193,477 đô la cho một con gấu Steiff có một không hai tại một cuộc đấu giá từ thiện, đã mở Bảo tàng gấu JeJu ở Hàn Quốc. Bảo tàng gấu Teddy Jeju mở cửa đặc biệt dành cho các nhà sưu tập châu Âu và vô cùng phấn khích hơn bao giờ hết với trò giải trí &quot;gấu Teddy&quot; đặc biệt.</p>

<p><strong><a href="http://spineditor.com">Đã test được anh ơi </a></strong></p>
